### PR TITLE
update parse_page regex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 
 rvm:
-  - '2.2.2'
-  - '2.3.0'
   - '2.4.0'
+  - '2.5.0'
+  - '2.6.0'
 
 script: bundle exec rspec --pattern spec/{codebase/*,requests/api/v1/*}
 

--- a/curry.rb
+++ b/curry.rb
@@ -71,7 +71,9 @@ end
 
 get '/ncf/:rnc/:ncf' do|rnc, ncf|
 	agent = Mechanize.new
+        agent.user_agent  = Scraper::USER_AGENTS.sample
 	page = agent.get 'http://www.dgii.gov.do/app/WebApps/Consultas/NCF/ConsultaNCF.aspx'
+
 	form = page.form id: 'form1'
 
 	rnc.gsub!(/\D/, '')
@@ -93,11 +95,11 @@ get '/ncf/:rnc/:ncf' do|rnc, ncf|
 	{valid: !!$&}.to_json
 end
 
-
 get '/rnc/:keyword' do|keyword|
 	content_type 'application/json'
 
 	agent = Mechanize.new
+        agent.user_agent  = Scraper::USER_AGENTS.sample
 	page  = agent.get 'http://www.dgii.gov.do/app/WebApps/Consultas/rnc/RncWeb.aspx'
 
 	form = page.form name: 'Form1'

--- a/scraper.rb
+++ b/scraper.rb
@@ -316,21 +316,10 @@ class Scraper::BLH
 			return
 		end
 
-		if node = @agent.page.search('//div[@id="usdbuy"]').first
-			@dollar[:buying_rate] = node.text[/[\d.]+/].to_s
-		end
+		node  = @agent.page.search("//div[@class='iwithtext']/div[@class='iwt-text']/p")
 
-		if node = @agent.page.search('//div[@id="usdsell"]').first
-			@dollar[:selling_rate] = node.text[/[\d.]+/].to_s
-		end
-
-		if node = @agent.page.search('//div[@id="eurbuy"]').first
-			@euro[:buying_rate] = node.text[/[\d.]+/].to_s
-		end
-
-		if node = @agent.page.search('//div[@id="eursell"]').first
-			@euro[:selling_rate] = node.text[/[\d.]+/].to_s
-		end
+		@dollar[:buying_rate], @dollar[:selling_rate] = node.text[/DÓLAR.*[\d.]+/].to_s.scan(/[\d.]+/)
+		@euro[:buying_rate], @euro[:selling_rate]     = node.text[/EUROS.*[\d.]+/].to_s.scan(/[\d.]+/)
 	end
 
 	DATA_URI = URI('https://www.blh.com.do/')

--- a/scraper.rb
+++ b/scraper.rb
@@ -80,8 +80,8 @@ class Scraper::Info
 	private
 
 	def compute_mean(currency, rate_type)
-		n   = BigDecimal.new(0)
-		sum = BigDecimal.new(0)
+		n   = BigDecimal(0)
+		sum = BigDecimal(0)
 
 		@entities.each do|entity|
 			next unless entity
@@ -91,7 +91,7 @@ class Scraper::Info
 			next unless rate
 
 			n   += 1
-			sum += BigDecimal.new(1) / BigDecimal.new(rate)
+			sum += BigDecimal(1) / BigDecimal(rate)
 		end
 
 		("%.04f" % (n/sum))[/\d+\.\d{2}/].to_s


### PR DESCRIPTION
Lopez de Haro Bank updated their web page hence the place where they display their rates.
this change updates the method parse_page so it can reliably obtain the rates from the
page.

This PR effectively fix issue #16. Once merged, issue #16 would be close.

Please note that issue #16 received a quick fix so people running this application on production environments could update as soon as possible.

